### PR TITLE
Change in miopen.hpp and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ ROCM_PATH?= $(wildcard /opt/rocm)
 HIP_PATH?= $(wildcard /opt/rocm/hip)
 HIPCC=$(HIP_PATH)/bin/hipcc
 INCLUDE_DIRS=-I$(HIP_PATH)/include -I$(ROCM_PATH)/include -I$(ROCM_PATH)/hipblas/include
-LD_FLAGS=-L$(ROCM_PATH)/lib -L$(ROCM_PATH)/opencl/lib/x86_64 -lMIOpen -lOpenCL -lmiopengemm -lhipblas-hcc -lrocblas-hcc
+LD_FLAGS=-L$(ROCM_PATH)/lib -L$(ROCM_PATH)/opencl/lib/x86_64 -lMIOpen -lOpenCL -lmiopengemm -lhipblas -lrocblas
 TARGET=--amdgpu-target=gfx900
 LAYER_TIMING=1
 

--- a/miopen.hpp
+++ b/miopen.hpp
@@ -2,7 +2,7 @@
 #define MY_MIOPEN_HPP
 
 #include <miopen/miopen.h>
-#include <hipblas/hipblas.h>
+#include <hipblas.h>
 //#include <gperftools/profiler.h>
 
 #include <iostream>


### PR DESCRIPTION
As per latest release 1.6.4 of rocm driver , library name of rocblas and hipblas needs to be changed from ""-lhipblas-hcc , -lrocblas-hcc" to ""-lhipblas -lrocblas"
Hence, Makefile needs modification as below
LD_FLAGS=-L$(ROCM_PATH)/lib -L$(ROCM_PATH)/opencl/lib/x86_64 -lMIOpen -lOpenCL -lmiopengemm -lhipblas -lrocblas

Besides this, 1 minor modification requires in miopen.hpp as below
#include <hipblas/hipblas.h> to #include <hipblas.h>

Only after above 2 modification, we can able to build the miopen-benchmark tests on rocm release 1.6.4